### PR TITLE
Include filenames in `git ls-tree` output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,26 +22,18 @@ jobs:
           extra_tree_objects: |
             test/.dockerignore
             test/Dockerfile
-          extra_values: |
-            test/.dockerignore
-            test/Dockerfile
       # Expected hash generated from command below
-      # {\
-      #   git ls-tree -r --format='%(objectname)' --full-tree HEAD \
-      #     test/a/b \
-      #     test/context/file \
-      #     test/filename \
-      #     test/.dockerignore \
-      #     test/Dockerfile\
-      #   ; \
-      #   printf "test/a/b\ntest/context/file\ntest/filename\ntest/.dockerignore\ntest/Dockerfile" | \
-      #     git hash-object --stdin\
-      #   ;\
-      # } | git hash-object --stdin
+      # git ls-tree -r --format='%(objectname) %(path)' --full-tree HEAD \
+      #   test/a/b \
+      #   test/context/file \
+      #   test/filename \
+      #   test/.dockerignore \
+      #   test/Dockerfile | \
+      # git hash-object --stdin
       - name: Check
         run: |
           echo "${{ toJson(steps.generate) }}"
-          if [ "${{ steps.generate.outputs.hash }}" != "6d09883618bd309806be67847737b1a5a4aa1f40" ]; then
+          if [ "${{ steps.generate.outputs.hash }}" != "6c867c528d4bf0844d5176f78f6abfee0adfff2b" ]; then
             echo "::error::Invalid hash value"
             exit 1
           fi

--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,6 @@ inputs:
   extra_tree_objects:
     description: "Tree objects (files) to be included in addition to the docker image context"
     required: false
-  extra_values:
-    description: "Additional values that should be included when generating the hash"
-    required: false
 
 outputs:
   hash:

--- a/src/action.js
+++ b/src/action.js
@@ -9,12 +9,10 @@ async function run() {
   try {
     const build_context = core.getInput("build_context");
     const extra_tree_objects = core.getMultilineInput("extra_tree_objects");
-    const extra_values = core.getMultilineInput("extra_values");
 
-    core.startGroup(`Input`);
+    core.startGroup(`Parsed config values`);
     core.info(build_context);
     core.info(extra_tree_objects);
-    core.info(extra_values);
     core.endGroup();
 
     await core.group(`Build context image`, async () => {
@@ -50,12 +48,10 @@ async function run() {
     core.startGroup(`Collect all file object names from git tree`);
     const tree_object_paths = image_context.split("\n");
     tree_object_paths.push(...extra_tree_objects);
-    // TODO: If we format `%(path)` as well, there's no need for the follow up
-    //       `hash-object` of filenames below, right?
     const ls_tree_cmd = [
       "ls-tree",
       "-r",
-      "--format=%(objectname)",
+      "--format=%(objectname) %(path)",
       "--full-tree",
       "HEAD",
     ];
@@ -65,41 +61,10 @@ async function run() {
     });
     core.endGroup();
 
-    if (
-      tree_object_names.stdout.trim().split("\n").length !==
-      tree_object_paths.length
-    ) {
-      core.setFailed(
-        `Object paths did not match the intended amount of objects in the tree (${
-          tree_object_names.stdout.trim().split("\n").length
-        } != ${tree_object_paths.length})`
-      );
-      return;
-    }
-
-    core.startGroup(`Generate filenames hash`);
-    const filenames = image_context.split("\n");
-    filenames.push(...extra_values);
-    core.info(filenames.join("\n"));
-    const filenames_hashes = await exec.getExecOutput(
-      "git",
-      ["hash-object", "--stdin"],
-      {
-        failOnStdErr: true,
-        input: Buffer.from(filenames.join("\n"), "utf-8"),
-      }
-    );
-    core.endGroup();
-
-    core.startGroup(`Generate hash from filenames and git tree object names`);
+    core.startGroup(`Generate hash from git tree objects`);
     const hash = await exec.getExecOutput("git", ["hash-object", "--stdin"], {
       failOnStdErr: true,
-      input: Buffer.from(
-        // Only trim "prefixing" part before join, so that the resulting line has a
-        // newline as suffix.
-        [tree_object_names.stdout.trim(), filenames_hashes.stdout].join("\n"),
-        "utf-8"
-      ),
+      input: Buffer.from(tree_object_names.stdout, "utf-8"),
     });
     core.endGroup();
 

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -10,39 +10,23 @@ describe("run", () => {
     process.env["INPUT_BUILD_CONTEXT"] = "./test";
     process.env["INPUT_EXTRA_TREE_OBJECTS"] =
       "test/.dockerignore\ntest/Dockerfile";
-    process.env["INPUT_EXTRA_VALUES"] = "test/.dockerignore\ntest/Dockerfile";
     // Expected hash generated from command below
-    // {\
-    //   git ls-tree -r --format='%(objectname)' --full-tree HEAD \
-    //     test/a/b \
-    //     test/context/file \
-    //     test/filename \
-    //     test/.dockerignore \
-    //     test/Dockerfile\
-    //   ; \
-    //   printf "test/a/b\ntest/context/file\ntest/filename\ntest/.dockerignore\ntest/Dockerfile" | \
-    //     git hash-object --stdin\
-    //   ;\
-    // } | git hash-object --stdin
+    // git ls-tree -r --format='%(objectname) %(path)' --full-tree HEAD \
+    //   test/a/b \
+    //   test/context/file \
+    //   test/filename \
+    //   test/.dockerignore \
+    //   test/Dockerfile | \
+    // git hash-object --stdin
     await run();
     // See https://github.com/actions/toolkit/issues/777 regarding the newline..
     expect(process.stdout.write).toHaveBeenLastCalledWith(
-      `::set-output name=hash::6d09883618bd309806be67847737b1a5a4aa1f40\n`
+      `::set-output name=hash::6c867c528d4bf0844d5176f78f6abfee0adfff2b\n`
     );
     // Expect a second run to produce the same output
     await run();
     expect(process.stdout.write).toHaveBeenLastCalledWith(
-      `::set-output name=hash::6d09883618bd309806be67847737b1a5a4aa1f40\n`
-    );
-  }, 30000);
-
-  test("errors when extra tree objects doesn't match", async () => {
-    const { run } = require("./action");
-    process.env["INPUT_BUILD_CONTEXT"] = "./test";
-    process.env["INPUT_EXTRA_TREE_OBJECTS"] = "non_matching_stuff";
-    await run();
-    expect(process.stdout.write).toHaveBeenLastCalledWith(
-      `::error::Object paths did not match the intended amount of objects in the tree (3 != 4)\n`
+      `::set-output name=hash::6c867c528d4bf0844d5176f78f6abfee0adfff2b\n`
     );
   }, 30000);
 


### PR DESCRIPTION
Removes the need of generating an additional hash for only filenames