### PR TITLE
Bump @actions/core to 1.10.0

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -140,7 +140,6 @@ const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(278);
 const os = __importStar(__nccwpck_require__(37));
 const path = __importStar(__nccwpck_require__(17));
-const uuid_1 = __nccwpck_require__(840);
 const oidc_utils_1 = __nccwpck_require__(41);
 /**
  * The code to exit an action
@@ -170,20 +169,9 @@ function exportVariable(name, val) {
     process.env[name] = convertedVal;
     const filePath = process.env['GITHUB_ENV'] || '';
     if (filePath) {
-        const delimiter = `ghadelimiter_${uuid_1.v4()}`;
-        // These should realistically never happen, but just in case someone finds a way to exploit uuid generation let's not allow keys or values that contain the delimiter.
-        if (name.includes(delimiter)) {
-            throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
-        }
-        if (convertedVal.includes(delimiter)) {
-            throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
-        }
-        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
-        file_command_1.issueCommand('ENV', commandValue);
+        return file_command_1.issueFileCommand('ENV', file_command_1.prepareKeyValueMessage(name, val));
     }
-    else {
-        command_1.issueCommand('set-env', { name }, convertedVal);
-    }
+    command_1.issueCommand('set-env', { name }, convertedVal);
 }
 exports.exportVariable = exportVariable;
 /**
@@ -201,7 +189,7 @@ exports.setSecret = setSecret;
 function addPath(inputPath) {
     const filePath = process.env['GITHUB_PATH'] || '';
     if (filePath) {
-        file_command_1.issueCommand('PATH', inputPath);
+        file_command_1.issueFileCommand('PATH', inputPath);
     }
     else {
         command_1.issueCommand('add-path', {}, inputPath);
@@ -241,7 +229,10 @@ function getMultilineInput(name, options) {
     const inputs = getInput(name, options)
         .split('\n')
         .filter(x => x !== '');
-    return inputs;
+    if (options && options.trimWhitespace === false) {
+        return inputs;
+    }
+    return inputs.map(input => input.trim());
 }
 exports.getMultilineInput = getMultilineInput;
 /**
@@ -274,8 +265,12 @@ exports.getBooleanInput = getBooleanInput;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setOutput(name, value) {
+    const filePath = process.env['GITHUB_OUTPUT'] || '';
+    if (filePath) {
+        return file_command_1.issueFileCommand('OUTPUT', file_command_1.prepareKeyValueMessage(name, value));
+    }
     process.stdout.write(os.EOL);
-    command_1.issueCommand('set-output', { name }, value);
+    command_1.issueCommand('set-output', { name }, utils_1.toCommandValue(value));
 }
 exports.setOutput = setOutput;
 /**
@@ -404,7 +399,11 @@ exports.group = group;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function saveState(name, value) {
-    command_1.issueCommand('save-state', { name }, value);
+    const filePath = process.env['GITHUB_STATE'] || '';
+    if (filePath) {
+        return file_command_1.issueFileCommand('STATE', file_command_1.prepareKeyValueMessage(name, value));
+    }
+    command_1.issueCommand('save-state', { name }, utils_1.toCommandValue(value));
 }
 exports.saveState = saveState;
 /**
@@ -470,13 +469,14 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.issueCommand = void 0;
+exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__nccwpck_require__(147));
 const os = __importStar(__nccwpck_require__(37));
+const uuid_1 = __nccwpck_require__(840);
 const utils_1 = __nccwpck_require__(278);
-function issueCommand(command, message) {
+function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
         throw new Error(`Unable to find environment variable for file command ${command}`);
@@ -488,7 +488,22 @@ function issueCommand(command, message) {
         encoding: 'utf8'
     });
 }
-exports.issueCommand = issueCommand;
+exports.issueFileCommand = issueFileCommand;
+function prepareKeyValueMessage(key, value) {
+    const delimiter = `ghadelimiter_${uuid_1.v4()}`;
+    const convertedValue = utils_1.toCommandValue(value);
+    // These should realistically never happen, but just in case someone finds a
+    // way to exploit uuid generation let's not allow keys or values that contain
+    // the delimiter.
+    if (key.includes(delimiter)) {
+        throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
+    }
+    if (convertedValue.includes(delimiter)) {
+        throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
+    }
+    return `${key}<<${delimiter}${os.EOL}${convertedValue}${os.EOL}${delimiter}`;
+}
+exports.prepareKeyValueMessage = prepareKeyValueMessage;
 //# sourceMappingURL=file-command.js.map
 
 /***/ }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.9.0",
+        "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1"
       },
       "devDependencies": {
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "dependencies": {
         "@actions/http-client": "^2.0.1",
         "uuid": "^8.3.2"
@@ -4643,9 +4643,9 @@
   },
   "dependencies": {
     "@actions/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "requires": {
         "@actions/http-client": "^2.0.1",
         "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/5monkeys/docker-image-context-hash-action#readme",
   "dependencies": {
-    "@actions/core": "^1.9.0",
+    "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1"
   },
   "devDependencies": {

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -1,15 +1,42 @@
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const uuid = require("uuid");
 const { test, beforeEach, describe } = require("@jest/globals");
 
-beforeEach(() => {
-  process.stdout.write = jest.fn();
-});
+const UUID = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d";
+const DELIMITER = `ghadelimiter_${UUID}`;
 
 describe("run", () => {
+  beforeAll(() => {
+    const dirPath = path.join(__dirname, `test`);
+    if (!fs.existsSync(dirPath)) {
+      fs.mkdirSync(dirPath);
+    }
+  });
+
+  beforeEach(() => {
+    process.env["GITHUB_OUTPUT"] = "";
+    process.stdout.write = jest.fn();
+
+    jest.spyOn(uuid, "v4").mockImplementation(() => UUID);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    const dirPath = path.join(__dirname, `test`);
+    fs.rmdirSync(dirPath);
+  });
+
   test("can output hash", async () => {
     const { run } = require("./action");
     process.env["INPUT_BUILD_CONTEXT"] = "./test";
     process.env["INPUT_EXTRA_TREE_OBJECTS"] =
       "test/.dockerignore\ntest/Dockerfile";
+    createFileCommandFile("OUTPUT");
     // Expected hash generated from command below
     // git ls-tree -r --format='%(objectname) %(path)' --full-tree HEAD \
     //   test/a/b \
@@ -19,15 +46,18 @@ describe("run", () => {
     //   test/Dockerfile | \
     // git hash-object --stdin
     await run();
-    // See https://github.com/actions/toolkit/issues/777 regarding the newline..
-    expect(process.stdout.write).toHaveBeenLastCalledWith(
-      `::set-output name=hash::6c867c528d4bf0844d5176f78f6abfee0adfff2b\n`
+    verifyFileCommand(
+      "OUTPUT",
+      serializeOutput("hash", "6c867c528d4bf0844d5176f78f6abfee0adfff2b")
     );
+    createFileCommandFile("OUTPUT");
     // Expect a second run to produce the same output
     await run();
-    expect(process.stdout.write).toHaveBeenLastCalledWith(
-      `::set-output name=hash::6c867c528d4bf0844d5176f78f6abfee0adfff2b\n`
+    verifyFileCommand(
+      "OUTPUT",
+      serializeOutput("hash", "6c867c528d4bf0844d5176f78f6abfee0adfff2b")
     );
+    expect(1).toBe(1);
   }, 30000);
 
   test("errors when given an invalid build context", async () => {
@@ -41,3 +71,25 @@ describe("run", () => {
     );
   });
 });
+
+function serializeOutput(key, value) {
+  return `${key}<<${DELIMITER}${os.EOL}${value}${os.EOL}${DELIMITER}${os.EOL}`;
+}
+
+function createFileCommandFile(command) {
+  const filePath = path.join(__dirname, `test/${command}`);
+  process.env[`GITHUB_${command}`] = filePath;
+  fs.appendFileSync(filePath, "", {
+    encoding: "utf8",
+  });
+}
+
+function verifyFileCommand(command, expectedContents) {
+  const filePath = path.join(__dirname, `test/${command}`);
+  const contents = fs.readFileSync(filePath, "utf8");
+  try {
+    expect(contents).toEqual(expectedContents);
+  } finally {
+    fs.unlinkSync(filePath);
+  }
+}

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -4,6 +4,8 @@ const os = require("os");
 const uuid = require("uuid");
 const { test, beforeEach, describe } = require("@jest/globals");
 
+jest.mock("uuid");
+
 const UUID = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d";
 const DELIMITER = `ghadelimiter_${UUID}`;
 


### PR DESCRIPTION
GitHub has [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) the save-output command in favor of special [environment files](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files). The support for these environment files has been added in version 1.10.0 of @actions/core. This changeset bumps @actions/core and adjusts the tests accordingly.